### PR TITLE
Episode 2: clj-async-profiler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,6 @@
   :dependencies [[org.clojure/clojure "1.10.0"]]
   :main ^:skip-aot clojure-quips.core
   :target-path "target/%s"
+  ;; allowAttachSelf is necessary for Dynamic Attach on Java 9+ used by clj-async-profiler: https://github.com/clojure-goes-fast/clj-async-profiler#usage)
+  :jvm-opts ["-Djdk.attach.allowAttachSelf=true"]
   :profiles {:uberjar {:aot :all}})

--- a/src/clojure_quips/002_async_profiler.clj
+++ b/src/clojure_quips/002_async_profiler.clj
@@ -1,0 +1,74 @@
+(ns clojure-quips.002-async-profiler
+  (:require [clj-async-profiler.core :as prof]))
+
+;;;; clj-async-profiler demo
+;;;; See:
+;;;; - Profiling tool: async-profiler: http://clojure-goes-fast.com/blog/profiling-tool-async-profiler/
+;;;; - Github: https://github.com/clojure-goes-fast/clj-async-profiler
+;;;; - Adds support for SVG's `width` and `height` options: https://github.com/clojure-goes-fast/clj-async-profiler/pull/10/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+(defn test-sum []
+  (reduce + (map inc (range 1000))))
+
+
+(defn test-div []
+  (reduce / (map inc (range 1000))))
+
+;; optimized with doubles
+#_(defn test-div []
+  (reduce / (map #(-> % inc double) (range 1000))))
+
+(defn burn-cpu [secs]
+  (let [start (System/nanoTime)]
+    (while (< (/ (- (System/nanoTime) start) 1e9) secs)
+      (test-sum)
+      (test-div))))
+
+(comment
+
+  (prof/list-event-types)
+  ;; => Basic events:
+  ;;      cpu
+  ;;      alloc
+  ;;      lock
+  ;;      wall
+  ;;      itimer
+
+  ;; start profiling
+  (prof/start {})
+  ;; or 
+  (prof/start {:event :alloc})
+  ;; then run the task
+  (burn-cpu 10)
+  ;; then stop the profiling
+  (prof/stop {})
+
+  ;; or profile the form itself (still system wide!)
+  (prof/profile {:width 2400}
+                (burn-cpu 10))
+
+  (prof/serve-files 8888) 
+
+  ;; end comment
+  )


### PR DESCRIPTION
Makre sure to set `"-Djdk.attach.allowAttachSelf=true"` when running on Java 9+.